### PR TITLE
Make compatible with TYPO3 12 LTS

### DIFF
--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -227,14 +227,15 @@ class ExportTableCommand extends AbstractTableCommand
                 $result->getRestrictions()->removeByType(HiddenRestriction::class);
             }
         }
-        $result = $result
+        $databaseRows = $result
             ->select('*')
             ->from($table)
-            ->execute();
+            ->executeQuery()
+            ->fetchAllAssociative();
         // Rows were found in the table
-        if ($result->rowCount()) {
+        if (count($databaseRows)) {
             $explodedResult = [];
-            foreach ($result as $row) {
+            foreach ($databaseRows as $row) {
                 $explodedRow = [];
                 foreach ($row as $column => $value) {
                     // If --use-only-columns option is used, the column is only added if it is part of the option value.
@@ -310,7 +311,7 @@ class ExportTableCommand extends AbstractTableCommand
             $yaml = Yaml::dump($dump, 20, $this->indentLevel);
         }
         // Generated YAML is written to file
-        if ($yaml !== '' && $result->rowCount() > 0) {
+        if ($yaml !== '' && count($databaseRows) > 0) {
             $io->note('Export to ' . GeneralUtility::getFileAbsFileName($this->file));
             $persistYamlFile = GeneralUtility::writeFile(
                 $filePath = GeneralUtility::getFileAbsFileName($this->file),
@@ -319,7 +320,7 @@ class ExportTableCommand extends AbstractTableCommand
             if ($persistYamlFile) {
                 $io->listing(
                     [
-                        $result->rowCount() . ' records were exported.'
+                        count($databaseRows) . ' records were exported.',
                     ]
                 );
                 $io->success('Successfully finished the export of ' . $table . ' into ' . GeneralUtility::getFileAbsFileName($this->file));

--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -227,15 +227,15 @@ class ExportTableCommand extends AbstractTableCommand
                 $result->getRestrictions()->removeByType(HiddenRestriction::class);
             }
         }
-        $databaseRows = $result
+        $result = $result
             ->select('*')
             ->from($table)
-            ->executeQuery()
-            ->fetchAllAssociative();
+            ->executeQuery();
+        $rowCount = $result->rowCount();
         // Rows were found in the table
-        if (count($databaseRows)) {
+        if ($rowCount) {
             $explodedResult = [];
-            foreach ($databaseRows as $row) {
+            while ($row = $result->fetchAssociative()) {
                 $explodedRow = [];
                 foreach ($row as $column => $value) {
                     // If --use-only-columns option is used, the column is only added if it is part of the option value.
@@ -311,7 +311,7 @@ class ExportTableCommand extends AbstractTableCommand
             $yaml = Yaml::dump($dump, 20, $this->indentLevel);
         }
         // Generated YAML is written to file
-        if ($yaml !== '' && count($databaseRows) > 0) {
+        if ($yaml !== '' && $rowCount > 0) {
             $io->note('Export to ' . GeneralUtility::getFileAbsFileName($this->file));
             $persistYamlFile = GeneralUtility::writeFile(
                 $filePath = GeneralUtility::getFileAbsFileName($this->file),
@@ -320,7 +320,7 @@ class ExportTableCommand extends AbstractTableCommand
             if ($persistYamlFile) {
                 $io->listing(
                     [
-                        count($databaseRows) . ' records were exported.',
+                        $rowCount . ' records were exported.',
                     ]
                 );
                 $io->success('Successfully finished the export of ' . $table . ' into ' . GeneralUtility::getFileAbsFileName($this->file));

--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -398,7 +398,7 @@ class ExportTableCommand extends AbstractTableCommand
         $fileSystem = new Filesystem();
         $filePathDirectory = GeneralUtility::dirname($filePath);
         if (strpos($filePath, Environment::getPublicPath() . '/') !== false
-            && !GeneralUtility::getApplicationContext()->isDevelopment()) {
+            && !Environment::getContext()->isDevelopment()) {
             throw new \RuntimeException(
                 'Please specify an absolute file path outside of the web root.',
                 1543830137

--- a/Classes/Hooks/Backend/ButtonBar/YamlExportButton.php
+++ b/Classes/Hooks/Backend/ButtonBar/YamlExportButton.php
@@ -23,7 +23,8 @@ class YamlExportButton
         $buttons = $params['buttons'];
 
         if (
-            (!isset($buttons[ButtonBar::BUTTON_POSITION_LEFT][6][0]) && !$buttons[ButtonBar::BUTTON_POSITION_LEFT][6][0] instanceof LinkButton) ||
+            !($buttons[ButtonBar::BUTTON_POSITION_LEFT][6][0] ?? false) ||
+            !$buttons[ButtonBar::BUTTON_POSITION_LEFT][6][0] instanceof LinkButton ||
             (!isset($buttons[ButtonBar::BUTTON_POSITION_LEFT][6][0]->getDataAttributes()['table']) || $buttons[ButtonBar::BUTTON_POSITION_LEFT][6][0]->getDataAttributes()['table'] !== 'be_groups')
         ) {
             return $buttons;

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^10 || ^11",
-		"symfony/yaml": "2.6 - 4.99 || ^5"
+		"typo3/cms-core": "^10 || ^11 || ^12",
+		"symfony/yaml": "2.6 - 4.99 || ^5 || ^6"
 	},
 	"extra": {
 		"typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^10",
+		"typo3/cms-core": "^10 || ^11",
 		"symfony/yaml": "2.6 - 4.99 || ^5"
 	},
 	"extra": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-11.5.99',
+            'typo3' => '10.4.0-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0-10.4.99',
+            'typo3' => '10.4.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,6 @@
 <?php
-defined('TYPO3_MODE') || die('Access denied.');
+
+defined('TYPO3_MODE') || defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     function ($extKey) {


### PR DESCRIPTION
Although #6 is still open, I start a next attempt 😉 

We are using this branch in our TYPO3 12 LTS projects to import and export records with CLI. Maybe you are interested to merge it into your repository.

The backend button is not yet adapted to TYPO3 12 LTS, because we have no need for it.