### PR TITLE
Compatibility with TYPO3 13

### DIFF
--- a/Classes/Backend/ButtonBar/YamlExportButton.php
+++ b/Classes/Backend/ButtonBar/YamlExportButton.php
@@ -71,8 +71,7 @@ class YamlExportButton
             // Add button directly to array instead of using ->getButtonBar as this needs too much memory
             $buttons[$options['buttonBarPosition']][$options['index']][] = $button;
         }
-        // @todo: Load Javascript with native ES6 modules instead of RequireJs (which is deprecated)
-        $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/YamlConfiguration/Backend');
+        $this->pageRenderer->loadJavaScriptModule('@supseven/yaml-configuration/Backend.js');
 
         // Persist final buttons configuration
         $event->setButtons($buttons);

--- a/Classes/Backend/ButtonBar/YamlExportButton.php
+++ b/Classes/Backend/ButtonBar/YamlExportButton.php
@@ -72,7 +72,10 @@ class YamlExportButton
             // Add button directly to array instead of using ->getButtonBar as this needs too much memory
             $buttons[$options['buttonBarPosition']][$options['index']][] = $button;
         }
-        $this->pageRenderer->loadJavaScriptModule('@supseven/yaml-configuration/Backend.js');
+
+        if (isset($button)) { // include JavaScript only if a button was created
+            $this->pageRenderer->loadJavaScriptModule('@supseven/yaml-configuration/Backend.js');
+        }
 
         // Persist final buttons configuration
         $event->setButtons($buttons);

--- a/Classes/Backend/ButtonBar/YamlExportButton.php
+++ b/Classes/Backend/ButtonBar/YamlExportButton.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExis
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Class YamlExportButton
@@ -110,11 +111,19 @@ class YamlExportButton
      */
     protected function isApplicableTable(string $table): bool
     {
-        if (!array_key_exists('table', $this->getRequest()->getQueryParams())) {
-            return false;
+        $typo3Version = VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version());
+        if ($typo3Version < 13000000) { // old check befor TYPO3 v13
+            if (!array_key_exists('table', $this->getRequest()->getQueryParams())) {
+                return false;
+            }
+            return ($this->getRequest()->getAttributes()['routing']->getRoute()->getPath() === '/module/web/list') &&
+                ($this->getRequest()->getQueryParams()['table'] === $table);
         }
-        return ($this->getRequest()->getAttributes()['routing']->getRoute()->getPath() === '/module/web/list') &&
-            ($this->getRequest()->getQueryParams()['table'] === $table);
+
+        return (
+            $this->getRequest()->getAttributes()['routing']->getRoute()->getPath() === '/record/edit'
+            && isset($this->getRequest()->getQueryParams()['edit'][$table])
+        );
     }
 
     private function getRequest(): ServerRequestInterface

--- a/Classes/Command/AbstractTableCommand.php
+++ b/Classes/Command/AbstractTableCommand.php
@@ -83,16 +83,16 @@ class AbstractTableCommand extends Command
         $result = $this->queryBuilderForTable($table)
             ->select('*')
             ->from($table)
-            ->execute()
-            ->fetch();
+            ->executeQuery()
+            ->fetchAssociative();
         if ($result) {
             $columnNames = \array_keys($result);
             $this->tableColumnCache[$table] = $columnNames;
         } else {
             $result = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($table);
-            $result = $result->getSchemaManager()->listTableColumns($table);
-            foreach ($result as $columnName => $columnProperties) {
-                $columnNames[] = $columnName;
+            $result = $result->getSchemaInformation()->introspectTable($table)->getColumns();
+            foreach ($result as $columnProperties) {
+                $columnNames[] = $columnProperties->getName();
             }
             $this->tableColumnCache[$table] = $columnNames;
         }

--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -188,7 +188,7 @@ class ExportTableCommand extends AbstractTableCommand
      * @param OutputInterface $output
      * @return int|void|null
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         // Output information about the command

--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -91,8 +91,8 @@ class ExportTableCommand extends AbstractTableCommand
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
-        $this->setSkipColumns(GeneralUtility::trimExplode(',', $input->getOption('skip-columns'), true));
-        $this->setExplodeColumns(GeneralUtility::trimExplode(',', $input->getOption('explode-columns'), true));
+        $this->setSkipColumns(GeneralUtility::trimExplode(',', $input->getOption('skip-columns') ?? '', true));
+        $this->setExplodeColumns(GeneralUtility::trimExplode(',', $input->getOption('explode-columns') ?? '', true));
         if ($input->getOption('use-only-columns')) {
             $this->setUseOnlyColumns(GeneralUtility::trimExplode(',', $input->getOption('use-only-columns'), true));
         }

--- a/Classes/Command/ExportTableCommand.php
+++ b/Classes/Command/ExportTableCommand.php
@@ -271,7 +271,7 @@ class ExportTableCommand extends AbstractTableCommand
                                         )
                                     )
                             )
-                            ->execute();
+                            ->executeQuery();
                         $usergroupsTitles = [];
                         foreach ($usergroups as $singleUserGroup) {
                             $usergroupsTitles[] = $singleUserGroup['title'];

--- a/Classes/Command/ImportTableCommand.php
+++ b/Classes/Command/ImportTableCommand.php
@@ -76,7 +76,7 @@ class ImportTableCommand extends AbstractTableCommand
      * @param OutputInterface $output
      * @return int|void|null
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $this->informationalHeader($io, $input);

--- a/Classes/Command/ImportTableCommand.php
+++ b/Classes/Command/ImportTableCommand.php
@@ -146,7 +146,7 @@ class ImportTableCommand extends AbstractTableCommand
                             )
                         );
                     }
-                    $row = $row->where(...$whereClause)->execute()->fetch();
+                    $row = $row->where(...$whereClause)->executeQuery()->fetchAssociative();
                 }
                 if ($row) {
                     // Update row as the matched row exists in the table

--- a/Classes/Service/YamlExportService.php
+++ b/Classes/Service/YamlExportService.php
@@ -64,7 +64,7 @@ class YamlExportService
             ]);
         }
 
-        $output = '';
+        $output = [];
         $returnValue = 0;
         $pathAndFileName = ExtensionManagementUtility::extPath($this->config['extensionName']) . $this->config['path'] . $this->config['table'] . '.yaml';
 

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'imports' => [
+        '@supseven/yaml-configuration/' => 'EXT:yaml_configuration/Resources/Public/JavaScript/',
+    ],
+];

--- a/Resources/Public/JavaScript/Backend.js
+++ b/Resources/Public/JavaScript/Backend.js
@@ -1,3 +1,5 @@
+import Notification from "@typo3/backend/notification.js";
+
 (function() {
     var httpRequest;
     document.getElementsByClassName('t3js-yaml-export')[0].addEventListener('click', makeRequest);
@@ -20,29 +22,27 @@
             if (httpRequest.status === 200) {
                 var _response = JSON.parse(httpRequest.response);
 
-                Notification(_response)
+                notify(_response)
             } else {
                 console.log("error");
             }
         }
     }
 
-    function Notification(response) {
-        require(['TYPO3/CMS/Backend/Notification'], function(Notification) {
-            switch (response.status) {
-                case 1:
-                    Notification.warning(response.title, response.message);
-                    break;
-                case 255:
-                    Notification.notice(response.title, response.message);
-                    break;
-                case 500:
-                    Notification.error(response.title, response.message);
-                    break;
-                default:
-                    Notification.success(response.title, response.message);
-                    break;
-            }
-        });
+    function notify(response) {
+        switch (response.status) {
+            case 1:
+                Notification.warning(response.title, response.message);
+                break;
+            case 255:
+                Notification.notice(response.title, response.message);
+                break;
+            case 500:
+                Notification.error(response.title, response.message);
+                break;
+            default:
+                Notification.success(response.title, response.message);
+                break;
+        }
     }
 })();

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^11 || ^12 || ^13",
-		"symfony/yaml": "2.6 - 4.99 || ^5 || ^6 || ^7"
+		"typo3/cms-core": "^12 || ^13",
+		"symfony/yaml": "^5 || ^6 || ^7"
 	},
 	"extra": {
 		"typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^11 || ^12",
-		"symfony/yaml": "2.6 - 4.99 || ^5 || ^6"
+		"typo3/cms-core": "^11 || ^12 || ^13",
+		"symfony/yaml": "2.6 - 4.99 || ^5 || ^6 || ^7"
 	},
 	"extra": {
 		"typo3/cms": {


### PR DESCRIPTION
This version is compatible with TYPO3 13. I replaced the old JavaScript require method with the new one which was introduced in TYPO3 12. For this reason, I dropped support for versions olter than TYPO3 12.